### PR TITLE
revert

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -991,11 +991,17 @@ preprocess_args(dest, args::Tuple{}) = ()
 # Specialize this method if all you want to do is specialize on typeof(dest)
 @inline function copyto!(dest::AbstractArray, bc::Broadcasted{Nothing})
     axes(dest) == axes(bc) || throwdm(axes(dest), axes(bc))
-    # Performance optimization: broadcast!(identity, dest, A) is equivalent to copyto!(dest, A) if indices match
+    # Performance optimization: broadcast!(identity, dest, A) is equivalent to copyto!(dest, A) if indices match.
+    # However copyto!(dest, A) is very slow in many cases, implement a faster version here.
     if bc.f === identity && bc.args isa Tuple{AbstractArray} # only a single input argument to broadcast!
         A = bc.args[1]
         if axes(dest) == axes(A)
-            return copyto!(dest, A)
+            A′ = broadcast_unalias(dest, A)
+            iter = IndexStyle(dest) isa IndexCartesian ? dest : A′
+            @inbounds @simd for I in eachindex(iter)
+                dest[I] = A′[I]
+            end
+            return dest
         end
     end
     bc′ = preprocess(dest, bc)


### PR DESCRIPTION
```julia
a = randn(8,8,8,8); b = similar(a);
@btime $b[1:end,1:end,1:end,1:end] .= $a;               #2.389 μs (0 allocations: 0 bytes)
@btime @views copyto!($b[1:end,1:end,1:end,1:end], $a); #11.900 μs (0 allocations: 0 bytes)
@btime $b[1:end,1:end,1:end,1:end] = $a;                #5.517 μs (1 allocation: 48 bytes)
@btime $b[:,:,:,:] .= $a;                               #590.217 ns (0 allocations: 0 bytes)
@btime @views copyto!($b[:,:,:,:], $a);                 #1.940 μs (0 allocations: 0 bytes)
@btime $b[:,:,:,:] = $a;                                #5.333 μs (1 allocation: 48 bytes)

a = randn(16,16,16); b = similar(a);
@btime $b[1:end,1:end,1:end] .= $a;                     #911.111 ns (0 allocations: 0 bytes)
@btime @views copyto!($b[1:end,1:end,1:end], $a);       #9.600 μs (0 allocations: 0 bytes)
@btime $b[1:end,1:end,1:end] = $a;                      #3.150 μs (0 allocations: 0 bytes)
@btime $b[:,:,:] .= $a;                                 #530.208 ns (0 allocations: 0 bytes)
@btime @views copyto!($b[:,:,:], $a);                   #1.250 μs (0 allocations: 0 bytes)
@btime $b[:,:,:] = $a;                                  #3.087 μs (0 allocations: 0 bytes)

a = randn(64,64); b = similar(a);
@btime $b[1:end,1:end] .= $a;                           #523.438 ns (0 allocations: 0 bytes)
@btime @views copyto!($b[1:end,1:end], $a);             #8.800 μs (0 allocations: 0 bytes)
@btime $b[1:end,1:end] = $a;                            #2.856 μs (0 allocations: 0 bytes)
@btime $b[:,:] .= $a;                                   #517.617 ns (0 allocations: 0 bytes)
@btime @views copyto!($b[:,:], $a);                     #1.930 μs (0 allocations: 0 bytes)
@btime $b[:,:] = $a;                                    #2.856 μs (0 allocations: 0 bytes)
```
`.=` is always fastest now.